### PR TITLE
checkDirectory should use dir.exists, not file.exists

### DIFF
--- a/R/createEmptyRepo.R
+++ b/R/createEmptyRepo.R
@@ -402,7 +402,7 @@ checkDirectory <- function( directory, create = FALSE ){
   # check property of directory
   if ( !create ){
     # check whether repository exists
-    if ( !file.exists( directory ) ){
+    if ( !dir.exists( directory ) ){
       stop( paste0( "There is no such repository as ", directory ) )
     }
     # check if repository is proper (has backpack.db and gallery)


### PR DESCRIPTION
`checkDirectory` should use `dir.exists`, not `file.exists`, as `file.exists`
returns `FALSE` if a directory exists because it is not checking for a directory. 
The desired behaviour should be that `checkDirectory` returns `TRUE` if the directory exists.