### PR TITLE
Now CreateLocalRepo always returns repo path, even when Default=FALSE

### DIFF
--- a/R/createEmptyRepo.R
+++ b/R/createEmptyRepo.R
@@ -101,7 +101,7 @@ createLocalRepo <- function( repoDir, force = TRUE, default = FALSE ){
   if (default) {
     setLocalRepo(repoDir)
   }
-   
+  return(invisible( repoDir ))
 }
 
 #' @family archivist


### PR DESCRIPTION
All examples fail when `CreateLocalRepo` isn't invoked with `default=TRUE` parameter, because when `default=FALSE` the function returns NULL.

Why bother with the return value? - Because:

1. The `CreateLocalRepo` works very much like object factory, and a lot of people would assume it returns something more complex, than a string.
1. Indeed, sooner or later you might want to return something that would speed object lookup, like the SQL connection object itself or something even more elaborate. 

