### PR TITLE
Use archivist.hash.function to select desired hash algorithm

### DIFF
--- a/R/ahistory.R
+++ b/R/ahistory.R
@@ -75,7 +75,7 @@
 ahistory <- function(artifact = NULL, md5hash = NULL, repoDir = aoptions('repoDir'), format = "regular", alink = FALSE, ...) {
   # if artifact is set then calculate md5hash for it
   if (!is.null(artifact)) 
-    md5hash <- digest(artifact)
+    md5hash <- adigest(artifact)
   if (is.null(md5hash)) 
     stop("Either artifact or md5hash has to be set")
   

--- a/R/archivistOptions.R
+++ b/R/archivistOptions.R
@@ -88,6 +88,17 @@
 #' showRemoteRepo(subdir = 'ex2')
 #' 
 #' aoptions('subdir')
+#' 
+#' ## EXAMPLE 4 : SET sha256 as a hasing algorithm
+#' aoptions("hashFunction", value = "sha256")
+#' exampleRepoDir <- tempfile()
+#' createLocalRepo(exampleRepoDir)
+#' aoptions(key = "repoDir", value = exampleRepoDir)
+#' 
+#' data(iris)
+#' saveToLocalRepo(iris)
+#' getTagsLocal(digest::digest(iris, algo = "sha256"))
+#' 
 #' }
 #' 
 #' @family archivist

--- a/R/cache.R
+++ b/R/cache.R
@@ -88,7 +88,7 @@
 cache <- function( cacheRepo = NULL, FUN, ..., notOlderThan = NULL ) {
   tmpl <- list(...)
   tmpl$.FUN <- FUN
-  outputHash <- digest(tmpl)
+  outputHash <- adigest(tmpl)
   localTags <- showLocalRepo(cacheRepo, "tags")
   isInRepo <- localTags[localTags$tag == paste0("cacheId:", outputHash),,drop=FALSE]
    if (nrow(isInRepo) > 0) {

--- a/R/extractData.R
+++ b/R/extractData.R
@@ -9,12 +9,12 @@ extractData.ggplot <- function( object, parrentMd5hash, parentDir, isForce, ASCI
   extractedDF <- object$data
   # check if that artifact might have been already archived
   check <- executeSingleQuery( dir = parentDir , 
-                               paste0( "SELECT * from artifact WHERE md5hash ='", digest(extractedDF), "'") )[,1]
+                               paste0( "SELECT * from artifact WHERE md5hash ='", adigest(extractedDF), "'") )[,1]
     if ( length( check ) > 0 & isForce ) {
     warning( "This artifact's data was already archived. Another archivisation executed with success.")
   }
   # archive data
-  DFname <- digest(extractedDF)
+  DFname <- adigest(extractedDF)
   md5hashDF <- saveToRepo( extractedDF, archiveData = FALSE, repoDir = parentDir, 
                            artifactName = DFname, archiveTags = FALSE, force = isForce, ascii = ASCII,
                            archiveSessionInfo = FALSE, silent = TRUE)
@@ -26,12 +26,12 @@ extractData.lm <- function( object, parrentMd5hash, parentDir, isForce, ASCII ){
   extractedDF <- object$model
   # check if that artifact might have been already archived
   check <- executeSingleQuery( dir = parentDir , 
-                               paste0( "SELECT * from artifact WHERE md5hash ='", digest(extractedDF), "'") )[,1]
+                               paste0( "SELECT * from artifact WHERE md5hash ='", adigest(extractedDF), "'") )[,1]
   if ( length( check ) > 0 & isForce ) {
     warning( "This artifact's data was already archived. Another archivisation executed with success.")
   }
   # archive data
-  DFname <- digest(extractedDF)
+  DFname <- adigest(extractedDF)
   md5hashDF <- saveToRepo( extractedDF, archiveData = FALSE, repoDir = parentDir,
                            artifactName = DFname, archiveTags = FALSE, force = isForce, ascii = ASCII,
                            archiveSessionInfo = FALSE, silent = TRUE)
@@ -46,12 +46,12 @@ extractData.htest <- function( object, parrentMd5hash, parentDir, isForce, ASCII
   extractedDF2 <- get( strsplit(object$data.name, " and ")[[1]][2], envir = parent.frame(1) )
   # check if that artifact might have been already archived
   check <- executeSingleQuery( dir = parentDir , 
-                               paste0( "SELECT * from artifact WHERE md5hash ='", digest(list( extractedDF1, extractedDF2 )), "'") )[,1]
+                               paste0( "SELECT * from artifact WHERE md5hash ='", adigest(list( extractedDF1, extractedDF2 )), "'") )[,1]
   if ( length( check ) > 0 & isForce ) {
     warning( "This artifact's data was already archived. Another archivisation executed with success.")
   }
   # archive data
-  DFname <- digest(list( extractedDF1, extractedDF2 ))
+  DFname <- adigest(list( extractedDF1, extractedDF2 ))
   md5hashDF <- saveToRepo( list( extractedDF1, extractedDF2 ), 
                            archiveData = FALSE, repoDir = parentDir,
                            artifactName = DFname, archiveTags = FALSE,
@@ -71,12 +71,12 @@ extractData.lda <- function( object, parrentMd5hash, parentDir, isForce, ASCII )
     extractedDF <-  get( as.character( ( object$call ) )[3], envir = parent.frame(1) )
     # check if that artifact might have been already archived
     check <- executeSingleQuery( dir = parentDir , 
-                                 paste0( "SELECT * from artifact WHERE md5hash ='", digest(extractedDF), "'") )[,1]
+                                 paste0( "SELECT * from artifact WHERE md5hash ='", adigest(extractedDF), "'") )[,1]
     if ( length( check ) > 0 & isForce ) {
       warning( "This artifact's data was already archived. Another archivisation executed with success.")
     }
     # archive data
-    DFname <- digest(extractedDF)
+    DFname <- adigest(extractedDF)
     md5hashDF <- saveToRepo( extractedDF, archiveData = FALSE, repoDir = parentDir,
                              artifactName = DFname, archiveTags = FALSE, force = isForce,
                              ascii = ASCII, archiveSessionInfo = FALSE, silent = TRUE)
@@ -93,12 +93,12 @@ extractData.trellis <- function( object, parrentMd5hash, parentDir, isForce, ASC
   extractedDF <- get( as.character( object$call )[3], envir = parent.frame(1) )
   # check if that artifact might have been already archived
   check <- executeSingleQuery( dir = parentDir , 
-                               paste0( "SELECT * from artifact WHERE md5hash ='", digest(extractedDF), "'") )[,1]
+                               paste0( "SELECT * from artifact WHERE md5hash ='", adigest(extractedDF), "'") )[,1]
   if ( length( check ) > 0 & isForce ) {
     warning( "This artifact's data was already archived. Another archivisation executed with success.")
   }
   # archive data
-  DFname <- digest(extractedDF)
+  DFname <- adigest(extractedDF)
   md5hashDF <- saveToRepo( extractedDF, archiveData = FALSE, repoDir = parentDir,
                            artifactName = DFname, archiveTags = FALSE, force = isForce,
                            ascii = ASCII, archiveSessionInfo = FALSE, silent = TRUE)
@@ -115,12 +115,12 @@ extractData.twins <- function( object, parrentMd5hash, parentDir, isForce, ASCII
   extractedDF <- object$data
   # check if that artifact might have been already archived
   check <- executeSingleQuery( dir = parentDir , 
-                               paste0( "SELECT * from artifact WHERE md5hash ='", digest(extractedDF), "'") )[,1]
+                               paste0( "SELECT * from artifact WHERE md5hash ='", adigest(extractedDF), "'") )[,1]
   if ( length( check ) > 0 & isForce ) {
     warning( "This artifact's data was already archived. Another archivisation executed with success.")
   }
   # archive data
-  DFname <- digest(extractedDF)
+  DFname <- adigest(extractedDF)
   md5hashDF <- saveToRepo( extractedDF, archiveData = FALSE, repoDir = parentDir,
                            artifactName = DFname, archiveTags = FALSE, force = isForce, ascii = ASCII,
                            archiveSessionInfo = FALSE, silent = TRUE)
@@ -133,12 +133,12 @@ extractData.partition <- function( object, parrentMd5hash, parentDir, isForce, A
   extractedDF <- object$data
   # check if that artifact might have been already archived
   check <- executeSingleQuery( dir = parentDir , 
-                               paste0( "SELECT * from artifact WHERE md5hash ='", digest(extractedDF), "'") )[,1]
+                               paste0( "SELECT * from artifact WHERE md5hash ='", adigest(extractedDF), "'") )[,1]
   if ( length( check ) > 0 & isForce ) {
     warning( "This artifact's data was already archived. Another archivisation executed with success.")
   }
   # archive data
-  DFname <- digest(extractedDF)
+  DFname <- adigest(extractedDF)
   md5hashDF <- saveToRepo( extractedDF, archiveData = FALSE, repoDir = parentDir,
                            artifactName = DFname, archiveTags = FALSE, force = isForce, ascii = ASCII,
                            archiveSessionInfo = FALSE, silent = TRUE)
@@ -151,12 +151,12 @@ extractData.qda <- function( object, parrentMd5hash, parentDir, isForce, ASCII )
   extractedDF <-  get( as.character( ( object$call ) )[2], envir = parent.frame(1) )
   # check if that artifact might have been already archived
   check <- executeSingleQuery( dir = parentDir , 
-                               paste0( "SELECT * from artifact WHERE md5hash ='", digest(extractedDF), "'") )[,1]
+                               paste0( "SELECT * from artifact WHERE md5hash ='", adigest(extractedDF), "'") )[,1]
   if ( length( check ) > 0 & isForce ) {
     warning( "This artifact's data was already archived. Another archivisation executed with success.")
   }
   # archive data
-  DFname <- digest(extractedDF)
+  DFname <- adigest(extractedDF)
   md5hashDF <- saveToRepo( extractedDF, archiveData = FALSE, repoDir = parentDir,
                            artifactName = DFname, archiveTags = FALSE, force = isForce, ascii = ASCII,
                            archiveSessionInfo = FALSE, silent = TRUE)
@@ -178,12 +178,12 @@ extractData.glmnet <- function( object, parrentMd5hash, parentDir, isForce, ASCI
   extractedDF2 <- get( as.character( object$call )[3], envir = parent.frame(1) )
   # check if that artifact might have been already archived
   check <- executeSingleQuery( dir = parentDir , 
-                               paste0( "SELECT * from artifact WHERE md5hash ='", digest(c( extractedDF1, extractedDF1 )), "'") )[,1]
+                               paste0( "SELECT * from artifact WHERE md5hash ='", adigest(c( extractedDF1, extractedDF1 )), "'") )[,1]
   if ( length( check ) > 0 & isForce ) {
     warning( "This artifact's data was already archived. Another archivisation executed with success.")
   }
   # archive data
-  DFname <- digest(c( extractedDF1, extractedDF1 ))
+  DFname <- adigest(c( extractedDF1, extractedDF1 ))
   md5hashDF <- saveToRepo( c( extractedDF1, extractedDF1 ), archiveData = FALSE, 
                            repoDir = parentDir, artifactName = DFname,
                            archiveTags = FALSE, 
@@ -202,12 +202,12 @@ extractData.survfit <- function( object, parrentMd5hash, parentDir, isForce, ASC
   extractedDF <-  get( as.character( object$call )[3], envir = parent.frame(1) )
   # check if that artifact might have been already archived
   check <- executeSingleQuery( dir = parentDir , 
-                               paste0( "SELECT * from artifact WHERE md5hash ='", digest(extractedDF), "'") )[,1]
+                               paste0( "SELECT * from artifact WHERE md5hash ='", adigest(extractedDF), "'") )[,1]
   if ( length( check ) > 0 & isForce ) {
     warning( "This artifact's data was already archived. Another archivisation executed with success.")
   }
   # archive data
-  DFname <- digest(extractedDF)
+  DFname <- adigest(extractedDF)
   md5hashDF <- saveToRepo( extractedDF, archiveData = FALSE, repoDir = parentDir, 
                            artifactName = DFname, archiveTags = FALSE, force = isForce, ascii = ASCII,
                            archiveSessionInfo = FALSE, silent = TRUE)

--- a/R/md5hash.R
+++ b/R/md5hash.R
@@ -52,4 +52,4 @@
 #' @docType class
 invisible(NULL)
 
-adigest <- function(x) digest(x, algo = getOption("archivist.hash.function", default = "md5"))
+adigest <- function(x) digest(x, algo = archivist::aoptions("hashFunction"))

--- a/R/md5hash.R
+++ b/R/md5hash.R
@@ -51,3 +51,5 @@
 #' @name md5hash
 #' @docType class
 invisible(NULL)
+
+adigest <- function(x) digest(x, algo = getOption("archivist.hash.function", default = "md5"))

--- a/R/saveToRepo.R
+++ b/R/saveToRepo.R
@@ -175,7 +175,7 @@ saveToLocalRepo <- function(
             length(archiveSessionInfo) == 1, length(force) == 1, 
             length(value) == 1, length(ascii) == 1, length(artifactName) <= 1)
 
-  md5hash <- digest( artifact )
+  md5hash <- adigest( artifact )
   if (is.null(artifactName)) {
     artifactName <- md5hash
   }

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -12,6 +12,7 @@ setDefaultArchivistEnv <- function() {
   .ArchivistEnv$subdir <- "/"
   .ArchivistEnv$repoType <- "github"
   .ArchivistEnv$silent <- TRUE
+  .ArchivistEnv$hashFunction <- "md5"
   
   # Starting from version: 2.1.4 
   # archivist may use external database for local repository (e.g. Postgress)

--- a/tests/testthat/test_hash_functions.R
+++ b/tests/testthat/test_hash_functions.R
@@ -1,0 +1,17 @@
+test_that("test sha256", {
+  
+  aoptions("hashFunction", value = "sha256")
+  createLocalRepo("sha256", default = TRUE, force = TRUE)
+  invisible(aoptions("silent", TRUE))
+  data(iris)
+  
+  iris %a%
+    dplyr::filter(Sepal.Length < 16) %a%
+    lm(Petal.Length~Species, data=.) %a%
+    summary() -> obj
+  
+  hash1 <- digest::digest(dplyr::filter(iris, Sepal.Length < 16), algo = "sha256")
+  expect_equal(getTagsLocal(hash1), c("name:res_val", "name:iris %a% dplyr::filter(Sepal.Length < 16)"))
+  
+  deleteLocalRepo("sha256", deleteRoot = TRUE)
+})


### PR DESCRIPTION
I was wondering how to add the possibility to select other hashing algorithm without affecting the package structure.

In this pull request there's my proposition - just create simple wrapper on the `digest`, and use the environmental variable `archivist.hash.function` to specify desired algorithm.

```
adigest <- function(x) digest(x, algo = getOption("archivist.hash.function", default = "md5"))
```

What do you think about this solution?