### PR TITLE
flock::lock -- Database is locked -- when running in parallel cluster

### DIFF
--- a/R/createEmptyRepo.R
+++ b/R/createEmptyRepo.R
@@ -200,8 +200,13 @@ executeSingleQuery <- function( dir, query ) {
 }
 
 executeSingleSilentQuery <- function( dir, query ) {
+  lock.name = "~/.file.lock"
+  ll <- flock::lock(lock.name)
   conn <- getConnectionToDB( dir )
-  on.exit( dbDisconnect( conn ) )
+  on.exit( {
+    dbDisconnect( conn ) 
+    flock::unlock(ll)
+    })
   res <- dbExecute( conn, query )
   return( res )
 }


### PR DESCRIPTION
I have hit the issue where writing to SQLite from R via archivist (and reproducible) errors with: 
```
Error in checkForRemoteErrors(val) : 
  999 nodes produced errors; first error: database is locked
```

A small modification using the `flock` package (which archivist already uses) seems to fix this problem. 

Test with this:
```
#devtools::install("~/Documents/GitHub/archivist/", dependencies = FALSE)
library(archivist)
library(parallel)

# make cluster -- note this works if cluster is FORK also, but for simplicity, using default
#   which works on Linux, Mac, Windows
N <- detectCores()
cl <- makeCluster(N)

# make archivist repository
tmpdir <- tempdir()
if (!file.exists(file.path(tmpdir, "backpack.db"))) {
  archivist::createLocalRepo(tmpdir)
}

# make function that will write to archivist repository from with clusters
fun <- function(x, cacheRepo = tmpdir) {
  cache(rnorm, 1, cacheRepo = cacheRepo)
}

# Get archivist and repository directory loaded on cluster 
clusterEvalQ(cl = cl, {
  library(archivist)
})
clusterExport(cl = cl, "tmpdir")

# Run something that will write many times
# This will produce "database is locked" on Windows or Linux *most* of the time without the fix
for(i in 1:10) {
  a <- clusterMap(cl = cl, fun, 1:1000, .scheduling = "dynamic")
  message(i)
}

stopCluster(cl)
```