### PR TITLE
add method for recordedplots for extractMiniature

### DIFF
--- a/R/extractMiniature.R
+++ b/R/extractMiniature.R
@@ -19,6 +19,13 @@ extractMiniature.ggplot <- function( object, md5hash, parentDir, ..., width = 80
   addTag("format:png", md5hash, dir=parentDir)
 }
 
+extractMiniature.recordedplot <- function( object, md5hash, parentDir, ..., width = 800, height = 600 ){
+  png( file.path( parentDir, "gallery", paste0(md5hash, ".png" )), width, height )
+  grDevices::replayPlot( object )
+  dev.off()
+  addTag("format:png", md5hash, dir=parentDir)
+}
+
 extractMiniature.lm <- function( object, md5hash, parentDir, ... ){
   sink( file = file.path(parentDir, "gallery", paste0(md5hash, ".txt")) )
   print( summary( object ) )

--- a/R/saveToRepo.R
+++ b/R/saveToRepo.R
@@ -43,7 +43,7 @@
 #'
 #' Graphical parameters.
 #'
-#' If the artifact is of class \code{lattice} or \code{ggplot}, and
+#' If the artifact is of class \code{lattice}, \code{ggplot} or \code{recordedplot}, and
 #' \code{archiveMiniature = TRUE}, then it is
 #' possible to set the miniature's \code{width} and \code{height} parameters. By default they are set to
 #' \code{width = 800}, \code{height = 600}.

--- a/man/saveToRepo.Rd
+++ b/man/saveToRepo.Rd
@@ -138,7 +138,7 @@ the \pkg{archivist} package; see \link{Tags}.
 
 Graphical parameters.
 
-If the artifact is of class \code{lattice} or \code{ggplot}, and
+If the artifact is of class \code{lattice}, \code{ggplot} or \code{recordedplot}, and
 \code{archiveMiniature = TRUE}, then it is
 possible to set the miniature's \code{width} and \code{height} parameters. By default they are set to
 \code{width = 800}, \code{height = 600}.


### PR DESCRIPTION
Currently miniatures are not created for base plot objects. Navigating archived base plots in for example archivist::shinySearchInLocalRepo can be quite challenging.  However base plot objects can be recorded using grDevices::recordPlot() and replayed using grDevices::replayPlot. This proposed change exploits this behavior by creating an additional method for extractMiniature e.g. extractMiniature.recordedplot that allows these miniatures to be created.